### PR TITLE
Remove wrapping promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,16 +7,12 @@
  */
 module.exports = (promises, callback, errorHandler) => {
   return Promise.all(promises.map(promise => {
-    return new Promise((resolve) => {
-      promise
-        .then(result => {
-          callback(result);
-          resolve();
-        })
-        .catch(err => {
-          errorHandler(err);
-          resolve();
-        });
-    });
+    return promise
+      .then(result => {
+        callback(result);
+      })
+      .catch(err => {
+        errorHandler(err);
+      });
   }));
 };


### PR DESCRIPTION
Because we already use `promise`'s method, wrapping promise in another promise is a NO-OP.

Ideally we can further remove wrapping function for `callback` / `errorHandler`, that is: return statement would be `promise.then(callback).catch(errorHandler)`.  But point-free style will leak `callback` and `errorHandler`'s result polluting the outer `Promise.all`. 